### PR TITLE
Add Technically Speaking and Papercall to Call for Speakers resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ These sites list open calls for speakers.
 
 * [Call to Speakers](https://calltospeakers.com/)
 * [Lanyrd.com](http://lanyrd.com/calls/)
+* [Papercall](https://papercall.io)
+* [Technically Speaking](https://techspeak.email/)
 
 ### For Organizers
 


### PR DESCRIPTION
This PR adds resources, not a conference, and therefore will not follow the format laid out for conferences in contributing.md.